### PR TITLE
Fix double slash. Fix molecule for work with privileged:false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/rsyslog_role/tree/develop)
+### Changed
+- *[#8](https://github.com/idealista/rsyslog_role/issues/8) Fix double slash on **rsyslog_included_config_template_path** variable* @adrian-arapiles
+- *Change **molecule.yml** to work with privileged:false*
+### Added
+- *Add **create.yml** on molecule to avoid privileged:true. @adrian-arapiles*
 
 ## [1.2.0](https://github.com/idealista/rsyslog_role/tree/1.2.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased](https://github.com/idealista/rsyslog_role/tree/develop)
 ### Changed
 - *[#8](https://github.com/idealista/rsyslog_role/issues/8) Fix double slash on **rsyslog_included_config_template_path** variable* @adrian-arapiles
-- *Change **molecule.yml** to work with privileged:false*
+- *Change **molecule.yml** to work with privileged:false* @adrian-arapiles
 ### Added
-- *Add **create.yml** on molecule to avoid privileged:true. @adrian-arapiles*
+- *Add **create.yml** on molecule to avoid privileged:true.* @adrian-arapiles
 
 ## [1.2.0](https://github.com/idealista/rsyslog_role/tree/1.2.0)
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ rsyslog_work_directory: /var/spool/rsyslog
 rsyslog_config_file: /etc/rsyslog.conf
 rsyslog_include_config_path: /etc/rsyslog.d
 rsyslog_include_config_matcher: "{{ rsyslog_include_config_path }}/*.conf"
-rsyslog_included_config_template_path: "{{ playbook_dir }}/templates/{{ rsyslog_include_config_path }}"
+rsyslog_included_config_template_path: "{{ playbook_dir }}/templates{{ rsyslog_include_config_path }}"
 
 # List of rsyslog feature packages to install.
 # Check: https://www.rsyslog.com/doc/v8-stable/installation/packages.html#package-structure

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -1,0 +1,71 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: Dockerfile.j2
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+      with_items: "{{ platforms.results }}"
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(true) }}"
+      with_items: "{{ platforms.results }}"
+      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+
+    - name: Create docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "molecule_local/{{ item.image }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+        exposed_ports: "{{ item.exposed_ports | default(omit) }}"
+        published_ports: "{{ item.published_ports | default(omit) }}"
+        ulimits: "{{ item.ulimits | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
+        dns_servers: "{{ item.dns_servers | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
+        devices: "{{ item.devices | default(omit) }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: rsyslog-${MOLECULE_DISTRO:-debian9}
     image: geerlingguy/docker-${MOLECULE_DISTRO:-debian9}-ansible
+    privileged: false
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,13 +8,20 @@ lint:
 platforms:
   - name: rsyslog-${MOLECULE_DISTRO:-debian9}
     image: geerlingguy/docker-${MOLECULE_DISTRO:-debian9}-ansible
-    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
       - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/fuse/connections:/sys/fs/fuse/connections:ro'
+      - '/dev/hugepages:/dev/hugepages'
     groups:
       - rsyslog
+    tmpfs:
+      - '/tmp'
+      - '/run'
+      - '/run/lock'
+    devices:
+      - '/dev/fuse:/dev/fuse'
     command: '/lib/systemd/systemd'
 provisioner:
   name: ansible


### PR DESCRIPTION
- Fix double slash on rsyslog_included_config_template_path variable
- Change molecule.yml to work with privileged:false
- Add create.yml on molecule to avoid privileged:true

### Description of the Change
Fix double slash on variable.
Add **create.yml** and change **molecule.yml** to docker that it works with privileged:false

### Benefits
Path correctly.
When I try molecule with privileged:true my session close unexpectly, now not.

### Possible Drawbacks

I think not.
